### PR TITLE
Revert "remove build-time spec for `R_LIBS_USER`"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM rocker/rstudio:4.5.1
 ENV NB_USER=rstudio
 ENV NB_UID=1000
 ENV CONDA_DIR=/srv/conda
+ENV R_LIBS_USER=/srv/r
 ENV DEFAULT_PATH=${PATH}
 
 # Set ENV for all programs...
@@ -63,6 +64,10 @@ RUN rm -f /tmp/environment.yml
 
 USER root
 RUN rm -rf ${HOME}/.cache
+RUN mkdir -p ${R_LIBS_USER}
+# Create user owned R libs dir
+# This lets users temporarily install packages
+RUN install -d -o ${NB_USER} -g ${NB_USER} ${R_LIBS_USER}
 
 # Prepare VS Code extensions
 USER root
@@ -107,7 +112,7 @@ RUN for x in \
   reditorsupport.r \
   ; do code-server --extensions-dir ${VSCODE_EXTENSIONS} --install-extension $x; done
 
-ENV PATH=${CONDA_DIR}/bin:${DEFAULT_PATH}:/usr/lib/rstudio-server/bin
+ENV PATH=${CONDA_DIR}/bin:${R_LIBS_USER}/bin:${DEFAULT_PATH}:/usr/lib/rstudio-server/bin
 
 USER ${NB_USER}
 WORKDIR /home/${NB_USER}

--- a/install.R
+++ b/install.R
@@ -12,7 +12,8 @@ install_packages_with_versions <- function(packages) {
   if (length(to_install) > 0) {
     install.packages(to_install, available = available,
                      versions = packages[to_install],
-                     dependencies = TRUE)
+                     dependencies = TRUE,
+                     lib = Sys.getenv("R_LIBS_USER"))
   } else {
     cat("All packages are already installed.\n")
   }
@@ -24,7 +25,7 @@ required_packages <- c("renv", "remotes", "devtools")
 # Check and install required packages
 new_packages <- required_packages[!sapply(required_packages, requireNamespace, quietly = TRUE)]
 if (length(new_packages) > 0) {
-  install.packages(new_packages)
+  install.packages(new_packages, lib = Sys.getenv("R_LIBS_USER"))
 }
 
 packages = list(
@@ -99,5 +100,7 @@ packages = list(
 install_packages_with_versions(packages)
 
 # install GitHub packages
-remotes::install_github("hrbrmstr/waffle") # https://github.com/cal-icor/cal-icor-hubs/issues/294
-remotes::install_github("speegled/fosdata") # https://github.com/cal-icor/base-user-image/issues/117
+remotes::install_github("hrbrmstr/waffle", lib = "/srv/r") #Sys.getenv("R_LIBS_USER")) # https://github.com/cal-icor/cal-icor-hubs/issues/294
+remotes::install_github("speegled/fosdata", lib = "/srv/r") # https://github.com/cal-icor/base-user-image/issues/117
+
+.libPaths( c( "/srv/r" , .libPaths() ) )


### PR DESCRIPTION
Reverts cal-icor/rstudio-user-image#2

apparently rocker **doesn't** give write permissions to `/usr/local/lib...`.  le sigh.